### PR TITLE
Fix niLibVersion

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -9,7 +9,7 @@ nativeUtils {
             wpiVersion = "2024.+"
             opencvYear = "frc2023"
             googleTestYear = "frc2023"
-            niLibVersion = "2023.3.0"
+            niLibVersion = "2024.+"
             opencvVersion = "4.6.0-5"
             googleTestVersion = "1.12.1-2"
         }

--- a/config.gradle
+++ b/config.gradle
@@ -9,7 +9,7 @@ nativeUtils {
             wpiVersion = "2024.+"
             opencvYear = "frc2023"
             googleTestYear = "frc2023"
-            niLibVersion = "2024.+"
+            niLibVersion = "2024.1.1"
             opencvVersion = "4.6.0-5"
             googleTestVersion = "1.12.1-2"
         }


### PR DESCRIPTION
This seems to have been missed during the recent dependency updates to the template. The template fails to build on all of my systems unless niLib is updated as well.