### PR TITLE
2024 updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           submodules: true
       - name: Fetch all history and metadata
         run: |
-          git config --global --add safe.directory /__w/vendor-template/vendor-template
+          git config --global --add safe.directory /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
           git fetch --prune --unshallow
       - name: Build with Gradle
         run: ./gradlew build --max-workers 1 ${{ matrix.build-options }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
           path: build/allOutputs
 
   build-host:
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 12 
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +48,7 @@ jobs:
           - os: windows-2019
             artifact-name: Win64
             architecture: x64
-          - os: macos-11
+          - os: macos-12
             artifact-name: macOS
             architecture: x64
     name: "Build - ${{ matrix.artifact-name }}"

--- a/src/main/java/com/vendor/jni/VendorJNI.java
+++ b/src/main/java/com/vendor/jni/VendorJNI.java
@@ -5,17 +5,31 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import edu.wpi.first.util.RuntimeLoader;
 
+/**
+ * Demo class for loading the driver via JNI.
+ */
 public class VendorJNI {
   static boolean libraryLoaded = false;
   static RuntimeLoader<VendorJNI> loader = null;
 
+  /**
+   * Helper class for determining whether or not to load the driver on static initialization.
+   */
   public static class Helper {
     private static AtomicBoolean extractOnStaticLoad = new AtomicBoolean(true);
 
+    /**
+     * Get whether to load the driver on static init.
+     * @return true if the driver will load on static init
+     */
     public static boolean getExtractOnStaticLoad() {
       return extractOnStaticLoad.get();
     }
 
+    /**
+     * Set whether to load the driver on static init.
+     * @param load the new value
+     */
     public static void setExtractOnStaticLoad(boolean load) {
       extractOnStaticLoad.set(load);
     }
@@ -47,5 +61,12 @@ public class VendorJNI {
     libraryLoaded = true;
   }
 
+  /**
+   * Tells the driver to initialize.
+   * This is a demo of a native JNI method from the driver.
+   * 
+   * @return the int returned by the driver
+   * @see "VendorJNI.cpp"
+   */
   public static native int initialize();
 }


### PR DESCRIPTION
* Bump the macOS target to 12 (like the rest of wpilib)
* Change the CI action to not depend on the name of the repository
* Add Javadocs to VendorJNI.java for Java 17 compliance
* (The roboRIO tests all fail, so CI is still broken...._sigh_)