### PR TITLE
2024 tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
   build-host:
     env: 
-      MACOSX_DEPLOYMENT_TARGET: 11
+      MACOSX_DEPLOYMENT_TARGET: 12
     strategy:
       fail-fast: false
       matrix:
@@ -54,7 +54,7 @@ jobs:
     name: "Build - ${{ matrix.artifact-name }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Fetch all history and metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
       - name: Fetch all history and metadata
         run: |
-          git config --global --add safe.directory /__w/vendor-template/vendor-template
+          git config --global --add safe.directory /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
       - name: Build with Gradle
         run: ./gradlew build --max-workers 1 ${{ matrix.build-options }}
       - uses: actions/upload-artifact@v3

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'google-test'
   id 'edu.wpi.first.wpilib.repositories.WPILibRepositoriesPlugin' version '2020.2'
   id 'edu.wpi.first.NativeUtils' version '2024.6.1'
-  id 'edu.wpi.first.GradleJni' version '1.0.0'
+  id 'edu.wpi.first.GradleJni' version '1.1.0'
   id 'edu.wpi.first.GradleVsCode' version '2.1.0'
 }
 

--- a/src/main/java/com/vendor/jni/VendorJNI.java
+++ b/src/main/java/com/vendor/jni/VendorJNI.java
@@ -5,17 +5,31 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import edu.wpi.first.util.RuntimeLoader;
 
+/**
+ * Demo class for loading the driver via JNI.
+ */
 public class VendorJNI {
   static boolean libraryLoaded = false;
   static RuntimeLoader<VendorJNI> loader = null;
 
+  /**
+   * Helper class for determining whether or not to load the driver on static initialization.
+   */
   public static class Helper {
     private static AtomicBoolean extractOnStaticLoad = new AtomicBoolean(true);
 
+    /**
+     * Get whether to load the driver on static init.
+     * @return true if the driver will load on static init
+     */
     public static boolean getExtractOnStaticLoad() {
       return extractOnStaticLoad.get();
     }
 
+    /**
+     * Set whether to load the driver on static init.
+     * @param load the new value
+     */
     public static void setExtractOnStaticLoad(boolean load) {
       extractOnStaticLoad.set(load);
     }
@@ -47,5 +61,12 @@ public class VendorJNI {
     libraryLoaded = true;
   }
 
+  /**
+   * Tells the driver to initialize.
+   * This is a demo of a native JNI method from the driver.
+   * 
+   * @return the int returned by the driver
+   * @see "VendorJNI.cpp"
+   */
   public static native int initialize();
 }


### PR DESCRIPTION
* Make the GitHub CI runner not depend on the repo name
* Add Javadocs for VendorJNI for Java 17 warnings