### PR TITLE
Add javadoc link to WPILib docs and oracle java docs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ java {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17
 }
-javaVersion = "17"
+var javaVersion = "17"
 
 // Apply C++ configuration
 apply from: 'config.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 // Setup Javadocs to link back to WPILib docs
 javadoc {
     options {
-        links 'https://docs.oracle.com/en/java/javase/11/docs/api/', 'https://github.wpilib.org/allwpilib/docs/release/java/'
+        links 'https://docs.oracle.com/en/java/javase/17/docs/api/', 'https://github.wpilib.org/allwpilib/docs/release/java/'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ java {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17
 }
+javaVersion = "17"
 
 // Apply C++ configuration
 apply from: 'config.gradle'
@@ -45,7 +46,7 @@ dependencies {
 // Setup Javadocs to link back to WPILib docs
 javadoc {
     options {
-        links 'https://docs.oracle.com/en/java/javase/17/docs/api/', 'https://github.wpilib.org/allwpilib/docs/release/java/'
+        links "https://docs.oracle.com/en/java/javase/$javaVersion/docs/api/", 'https://github.wpilib.org/allwpilib/docs/release/java/'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,13 @@ dependencies {
     implementation 'edu.wpi.first.thirdparty.frc2024.opencv:opencv-java:4.8.0-4'
 }
 
+// Setup Javadocs to link back to WPILib docs
+javadoc {
+    options {
+        links 'https://docs.oracle.com/en/java/javase/11/docs/api/', 'https://github.wpilib.org/allwpilib/docs/release/java/'
+    }
+}
+
 // Set up exports properly
 nativeUtils {
   exportsConfigs {


### PR DESCRIPTION
Adds javadocs external links for javadocs generation. It may be worthwhile to add `javadocs.destinationDir = new File("$buildDir/repos/")` that way javadocs is also exported to the maven repo for an easy hosting solution.